### PR TITLE
Fix typo in "perform!" - plularize ReportsJob

### DIFF
--- a/app/models/raport/report.rb
+++ b/app/models/raport/report.rb
@@ -167,7 +167,7 @@ module Raport
     end
     
     def perform!
-      ReportJob.new(id).perform
+      ReportsJob.new(id).perform
     end
 
     def enqueue!


### PR DESCRIPTION
Apparently this method is never called, but it's a typo if it ever were used.